### PR TITLE
Improve AJAX error reporting for self-test

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 Plugin sponsored & developed by Neochrome, Inc.
 
+## 2.5.1
+* **Enhancement:** AJAX self-test failures now display detailed status information and server responses to aid debugging of coupon-related checks.
+
 ## 2.5.0
 * **Feature:** Added a "Grouping Type" toggle above the Custom Rules Scanner results, allowing reports to be viewed by Product (original behavior) or by the function/method containing each finding.
 

--- a/kiss-woo-shipping-settings-debugger.php
+++ b/kiss-woo-shipping-settings-debugger.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: KISS Woo Shipping Settings Debugger
  * Description: Exports UI-based WooCommerce shipping settings and scans theme files for custom shipping rules via AST.
- * Version:     2.5.0
+ * Version:     2.5.1
  * Author:      KISS Plugins
  * Requires at least: 6.0
  * Requires PHP: 7.4

--- a/self-test.php
+++ b/self-test.php
@@ -186,10 +186,19 @@ function kiss_wse_self_test_page_html() {
                     row.find('.test-message').html(message);
                     
                     runTest(index + 1); // Run the next test
-                }).fail(function() {
+                }).fail(function(jqXHR, textStatus, errorThrown) {
                     var icon = '<span style="color:red; font-size:1.5em; line-height:1;" class="dashicons dashicons-dismiss"></span>';
                     row.find('.test-icon').html(icon);
-                    row.find('.test-message').html('Failed to execute test (AJAX error).');
+
+                    var debugMsg = 'Failed to execute test (AJAX error).';
+                    if (textStatus || errorThrown) {
+                        debugMsg += ' ' + (textStatus || '') + (errorThrown ? ' - ' + errorThrown : '');
+                    }
+                    if (jqXHR && jqXHR.responseText) {
+                        debugMsg += '<br><pre style="white-space:pre-wrap;">' + $('<div/>').text(jqXHR.responseText).html() + '</pre>';
+                    }
+                    row.find('.test-message').html(debugMsg);
+                    console.error('KISS Shipping Debugger AJAX error:', textStatus, errorThrown, jqXHR);
                     $('#kiss-wse-run-self-tests').prop('disabled', false); // Stop on failure
                 });
             }


### PR DESCRIPTION
## Summary
- improve debugging details when an AJAX request fails during self-tests
- log AJAX error information in console for easier troubleshooting
- bump plugin to 2.5.1

## Testing
- `php -l self-test.php`
- `php -l kiss-woo-shipping-settings-debugger.php`


------
https://chatgpt.com/codex/tasks/task_b_689120ed2f24832eb55a98c449d1cd90